### PR TITLE
Refactor Augeas resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem "puppet-lint-version_comparison-check"
   gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-unquoted_string-check"
+  gem "safe_yaml", '~> 1.0.4'
 end
 
 group :development do

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,10 +15,13 @@ class cacti::config inherits cacti{
   augeas { 'cacti_perms':
     incl    => '/etc/httpd/conf.d/cacti.conf',
     lens    => 'Httpd.lns',
-    context => '/files/etc/httpd/conf.d/cacti.conf',
-    changes => [ 'set /files/etc/httpd/conf.d/cacti.conf/Directory[1]/IfModule[1]/directive/arg[1] all',
-      'set /files/etc/httpd/conf.d/cacti.conf/Directory[1]/IfModule[1]/directive/arg[2] granted',
-      'set /files/etc/httpd/conf.d/cacti.conf/Directory[1]/IfModule[2]/directive[3]/arg[2] all',
+    changes => [
+      'defnode req Directory[arg="/usr/share/cacti/"]/IfModule[arg="mod_authz_core.c"]/directive[.="Require"] "Require"',
+      'set $req/arg[1] "all"',
+      'set $req/arg[2] "granted"',
+
+      'defnode nomodauthzcore Directory[arg="/usr/share/cacti/"]/IfModule[arg="!mod_authz_core.c"] ""',
+      'set $nomodauthzcore/directive[.="Allow"]/arg[2] "all"',
     ],
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -36,8 +36,7 @@ describe 'cacti::config' do
         it do
           is_expected.to contain_augeas('cacti_perms').
             with({"incl"=>"/etc/httpd/conf.d/cacti.conf",
-                  "lens"=>"Httpd.lns",
-                  "context"=>"/files/etc/httpd/conf.d/cacti.conf"})
+                  "lens"=>"Httpd.lns"})
         end
         it do
           is_expected.to contain_cron__job('cacti').


### PR DESCRIPTION
This addresses an issue I ran into where the first Augeas set command was not being applied and no error was generated.

I was running PE 2016.1.2, RHEL 7.2, Augeas 1.4.0.
