### PR TITLE
Update cacti to version 1.1.10, add mysql defaults, fix selinux problem on Centos7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :test do
   gem "puppet-lint-version_comparison-check"
   gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-unquoted_string-check"
-  gem "safe_yaml", '~> 1.0.4'
 end
 
 group :development do

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class cacti::config inherits cacti{
   augeas { 'cacti_perms':
     incl    => '/etc/httpd/conf.d/cacti.conf',
     lens    => 'Httpd.lns',
+    context => '/files/etc/httpd/conf.d/cacti.conf',
     changes => [
       'defnode req Directory[arg="/usr/share/cacti/"]/IfModule[arg="mod_authz_core.c"]/directive[.="Require"] "Require"',
       'set $req/arg[1] "all"',
@@ -23,6 +24,7 @@ class cacti::config inherits cacti{
       'defnode nomodauthzcore Directory[arg="/usr/share/cacti/"]/IfModule[arg="!mod_authz_core.c"] ""',
       'set $nomodauthzcore/directive[.="Allow"]/arg[2] "all"',
     ],
+    notify => Service[$::cacti::managed_services],
   }
 
   cron::job { 'cacti':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,4 +7,14 @@ class cacti::install inherits cacti{
   package { $::cacti::cacti_package:
     ensure => present,
   }
+
+  if($::selinux_enforced){
+
+    # Move http scripts under /var/www/html, add symlink to /usr/share/cacti and
+    # restore context on the files
+    exec {'mv /usr/share/cacti /var/www/html/ && ln -s /var/www/html/cacti /usr/share && restorecon -v -r /var/www/html/cacti':
+      creates => '/var/www/html/cacti',
+      require => Package[$::cacti_package];
+    }
+  }
 }

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -2,11 +2,27 @@
 #
 # This class is called from cacti for database config.
 # git@github.com:puppetlabs/puppetlabs-mysql.git
-class cacti::mysql inherits ::cacti{
+class cacti::mysql(
+  $override_options = {
+    'mysqld' => {
+      'max_heap_table_size' => Integer($::memory['system']['total_bytes'] * 0.10),
+      'max_allowed_packet'  => '16M',
+      'tmp_table_size'      => '64M',
+      'join_buffer_size'    => '64M',
+      'innodb_file_per_table' => 'ON',
+      'innodb_buffer_pool_size' => Integer($::memory['system']['total_bytes'] * 0.25),
+      'innodb_doublewrite' => 'OFF',
+      'innodb_additional_mem_pool_size' => '80M',
+      'innodb_lock_wait_timeout' => '50',
+      'innodb_flush_log_at_trx_commit' => '2'
+      }
+    },
+  ) inherits ::cacti{
 
   class { '::mysql::server':
     root_password           => $::cacti::database_root_pass,
     remove_default_accounts => true,
+    override_options => $override_options,
   }
 
   mysql::db { 'cacti':
@@ -14,7 +30,15 @@ class cacti::mysql inherits ::cacti{
     password => $::cacti::database_pass,
     host     => $::cacti::database_host,
     grant    => ['ALL'],
-    sql      => '/usr/share/doc/cacti-0.8.8b/cacti.sql',
+    sql      => '/usr/share/doc/cacti-1.1.10/cacti.sql',
+    charset => 'utf8',
+    collate => 'utf8_general_ci',
+    notify => Exec['patch MySQL TimeZone support'],
+  }
+
+  exec { 'patch MySQL TimeZone support':
+    command => "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -Dmysql -p$::cacti::database_root_pass && mysql -p$::cacti::database_root_pass -D mysql -e \"GRANT SELECT ON mysql.time_zone_name TO ${::cacti::database_user}@localhost; flush privileges;\"",
+    refreshonly => true;
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/cnwrinc/cnwr-cacti",
   "issues_url": "https://github.com/cnwrinc/cnwr-cacti/issues",
   "dependencies": [
-    { "name":"rmueller/cron", "version_requirement":">=0.1.3" },
+    { "name":"puppet/cron", "version_requirement":">=1.1.0" },
     { "name":"puppetlabs/mysql", "version_requirement":">= 3.6.1" }
   ],
   "tags": ["cacti"],


### PR DESCRIPTION
4 separated commits:
* Update Gemfile for safe_yaml
* Add dependency on apache service if there is a change on apache `cacti.conf`
* Fix selinux problem on Centos7: bad context on apache files. Move the files from /usr/share/cacti to /var/www/html/cacti and restore context. Add a symlink to keep compatibility.
* Add default configuration for mysql database according to cacti 1.1.10 expectations.

Fully tested under Centos7 with selinux enforced.